### PR TITLE
docs: remove `defineNuxtConfig` import

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ yarn add -D @nuxtjs/fontaine
 ## Usage
 
 ```js
-import { defineNuxtConfig } from 'nuxt'
 
 export default defineNuxtConfig({
   modules: ['@nuxtjs/fontaine'],

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ yarn add -D @nuxtjs/fontaine
 ## Usage
 
 ```js
-
 export default defineNuxtConfig({
   modules: ['@nuxtjs/fontaine'],
   // If you are using a Google font or you don't have a @font-face declaration


### PR DESCRIPTION
Since Nuxt v3.0.0-rc.10, defineNuxtConfig is Auto Imported.