### PR TITLE
fix: add explicit imports for server inlining plugin

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -127,6 +127,7 @@ export default defineNuxtModule<ModuleOptions>({
         filename: 'font-override-inlining-plugin.server.ts',
         getContents: async () =>
           [
+            `import { defineNuxtPlugin, useHead } from '#imports'`,
             `const css = \`${(await css).replace(/\s+/g, ' ')}\``,
             `export default defineNuxtPlugin(() => { useHead({ style: [{ children: css ${!nuxt.options.dev && options.inject ? '+ __INLINED_CSS__ ' : ''
             }}] }) })`,


### PR DESCRIPTION
adds explicit imports to generated file to allow using `autoImport: false`
```ts
export default defineNuxtConfig({
  modules: ['@nuxtjs/fontaine'],
  imports: {
    autoImport: false
  },
})
```