### PR TITLE
chore: add optional root option for not public fonts

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -29,6 +29,8 @@ interface CustomFont {
   overrideName?: string
   /** If you want to customise the fallbacks on a per-font basis. */
   fallbacks?: string[]
+  /** If you want to customise font directory. Default is Nuxt public directory. */
+  root?: string
 }
 
 export interface ModuleOptions {
@@ -40,6 +42,8 @@ export interface ModuleOptions {
   fallbacks: string[]
   /** Fonts to generate override declarations for. This is only necessary if you do not have `@font-face` declarations for them in your CSS. */
   fonts: Array<string | CustomFont>
+  /** If you want to customise directory for all fonts. Default is Nuxt public directory. */
+  root?: string
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -70,13 +74,13 @@ export default defineNuxtModule<ModuleOptions>({
     const css = (async () => {
       let css = ''
       for (const font of options.fonts) {
-        const { family, src, overrideName, fallbacks } =
+        const { family, src, overrideName, fallbacks, root: fontRoot } =
           typeof font === 'string' ? ({ family: font } as CustomFont) : font
 
         let metrics = await getMetricsForFamily(family)
 
         if (!metrics && src && !hasProtocol(src)) {
-          const file = join(nuxt.options.srcDir, nuxt.options.dir.public, src)
+          const file = join(nuxt.options.srcDir, fontRoot ?? options.root ?? nuxt.options.dir.public, src)
           metrics = await readMetrics(pathToFileURL(file))
         }
 


### PR DESCRIPTION
## What is changed

Created `root` option for module and font options. If `root` option has been declared, it overrides the default Nuxt `public` path value for searching fonts in project.

## Motivation

If a developer wants to avoid using fonts stored in Nuxt's public path, they cannot do it. For example, a developer might want to use `assets` directory as fonts storage (or some others). `assets` directory is better when site will use caching tools (like the Cache-Control header) - then `assets` directory will generate unique filenames.