### PR TITLE
chore: use module-builder stub mode for more accurate types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build": "pnpm dev:prepare && nuxt-module-build",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
-    "dev:prepare": "pnpm nuxt-module-build --stub && nuxi prepare playground",
+    "dev:prepare": "pnpm nuxt-module-build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "docs:dev": "nuxi dev docs",
     "docs:build": "nuxi generate docs",
     "lint": "pnpm lint:all:eslint && pnpm lint:all:prettier",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,5 @@
   "compilerOptions": {
     "strict": true
   },
-  "extends": "./playground/.nuxt/tsconfig.json",
+  "extends": "./.nuxt/tsconfig.json",
 }


### PR DESCRIPTION
We added a `prepare` command for nuxt-module-build which allows creating type stubs directly from the module without needing to apply to the playground as well. (https://github.com/nuxt/module-builder/pull/124)

It's the default for new modules (https://github.com/nuxt/starter/pull/392).

This should allow us to match types more appropriately for module authors (for example, disallowing auto-imports) in future.