### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,6 @@ For best performance, you will need to inline _all_ your CSS, not just the font-
 
 ## Installation
 
-With `pnpm`
-
-```bash
-npx nuxi@latest module add fontaine
-```
-
-Or, with `npm`
-
-```bash
-npx nuxi@latest module add fontaine
-```
-
-Or, with `yarn`
-
 ```bash
 npx nuxi@latest module add fontaine
 ```

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ For best performance, you will need to inline _all_ your CSS, not just the font-
 With `pnpm`
 
 ```bash
-pnpm add -D @nuxtjs/fontaine
+npx nuxi@latest module add fontaine
 ```
 
 Or, with `npm`
 
 ```bash
-npm install -D @nuxtjs/fontaine
+npx nuxi@latest module add fontaine
 ```
 
 Or, with `yarn`
 
 ```bash
-yarn add -D @nuxtjs/fontaine
+npx nuxi@latest module add fontaine
 ```
 
 ## Usage


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
