### PR TITLE
chore: indicate compatibility with new v4 major

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -51,7 +51,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'fontMetrics',
     name: '@nuxtjs/fontaine',
     compatibility: {
-      nuxt: '^3.0.0-rc.6',
+      nuxt: '>=3.0.0-rc.6',
     },
   },
   defaults: nuxt => ({


### PR DESCRIPTION
With Nuxt 4 on the horizon, this updates the module compatibility definition to allow it to be installed on Nuxt v4. (Otherwise Nuxt will indicate the module might not be compatible.)

When Nuxt v4 comes out then you might decide or need to make breaking changes in this module and release a new major, but hopefully the migration should be smoother. 🙏 

👉 You can follow this and other changes in https://github.com/nuxt/nuxt/issues/27613 - please feel free to provide feedback as well!