### PR TITLE
chore(module): update compatibility to support Nuxt 4.x

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -51,7 +51,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'fontMetrics',
     name: '@nuxtjs/fontaine',
     compatibility: {
-      nuxt: '>=3.0.0-rc.6',
+      nuxt: '>=3.0.0-rc.6 || ^4.0.0',
     },
   },
   defaults: nuxt => ({


### PR DESCRIPTION
This pull request includes a small change to the `compatibility` field in the `defineNuxtModule` function within the `src/module.ts` file. The change updates the Nuxt.js version compatibility to include versions `>=3.0.0-rc.6` and `^4.0.0`.

* [`src/module.ts`](diffhunk://#diff-030fc083b2cbf5cf008cfc0c49bb4f1b8d97ac07f93a291d068d81b4d1416f70L54-R54): Updated `compatibility` field to support Nuxt.js versions `>=3.0.0-rc.6 || ^4.0.0`.

Resolves https://github.com/nuxt-modules/fontaine/issues/444